### PR TITLE
fix index checking in remove_before

### DIFF
--- a/src/collections/queue.rs
+++ b/src/collections/queue.rs
@@ -308,7 +308,7 @@ impl<T> FixedIndexQueue<T> {
         self.internal.clear();
     }
 
-    /// Removes values before `index`. Should make sure `index` is valid.
+    /// Removes values before `index`. Should make sure `index` is valid or is the next index.
     ///
     /// # Examples
     /// ```
@@ -321,15 +321,24 @@ impl<T> FixedIndexQueue<T> {
     ///
     /// queue.remove_before(2);
     /// assert_eq!(queue.len(), 1);
+    ///
+    /// assert_eq!(queue.push_back(44), 3);
+    /// queue.remove_before(4);
+    /// assert_eq!(queue.len(), 0);
     /// ```
     #[inline]
     pub fn remove_before(&mut self, index: usize) {
-        assert!(self.idx_is_valid(index), "index {} isn't valid", index);
+        assert!(
+            self.idx_is_valid(index) || index == self.next_index(),
+            "index {} is invalid",
+            index
+        );
 
         let mut count = index.wrapping_sub(self.offset);
         while count > 0 {
             self.internal.pop_front();
             count -= 1;
+            self.offset = self.offset.wrapping_add(1);
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,4 +189,31 @@ mod tests {
         assert_eq!(spans1.len(), 25);
         assert_eq!(spans2.len(), 25);
     }
+
+    #[test]
+    fn multiple_scopes_without_spans() {
+        let (spans1, spans2, spans3) = {
+            let (c1, c2, c3) = {
+                let (root_scope1, collector1) = root_scope("root1");
+                let (root_scope2, collector2) = root_scope("root2");
+                let (root_scope3, collector3) = root_scope("root3");
+
+                let _sg1 = root_scope1.start_scope();
+                let _sg2 = root_scope2.start_scope();
+                let _sg3 = root_scope3.start_scope();
+
+                (collector1, collector2, collector3)
+            };
+
+            (
+                c1.collect(true, None, None),
+                c2.collect(true, None, None),
+                c3.collect(true, None, None),
+            )
+        };
+
+        assert_eq!(spans1.len(), 1);
+        assert_eq!(spans2.len(), 1);
+        assert_eq!(spans3.len(), 1);
+    }
 }


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

Previously, if there's no span in a scope, it will panic at LocalScopeGuard's drop. Fixed it.