### PR TITLE
Slight refactor

### DIFF
--- a/benches/compare.rs
+++ b/benches/compare.rs
@@ -49,13 +49,13 @@ fn opentelemetry_harness() {
 fn minitrace_harness() {
     fn dummy_minitrace() {
         for _ in 0..99 {
-            let _guard = minitrace::Span::start("child");
+            let _guard = minitrace::Span::enter("child");
         }
     }
 
     {
         let (root_scope, collector) = minitrace::Scope::root("parent");
-        let _g = root_scope.attach_and_observe();
+        let _g = root_scope.enter();
 
         dummy_minitrace();
 

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -1,7 +1,7 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use minitrace::Observer;
+use minitrace::LocalCollector;
 use minitrace::*;
 use minitrace_macro::trace;
 
@@ -26,9 +26,9 @@ fn trace_wide_raw_bench(c: &mut Criterion) {
         "trace_wide_raw",
         |b, len| {
             b.iter(|| {
-                let observer = Observer::attach().unwrap();
+                let local_collector = LocalCollector::start();
                 dummy_iter(*len);
-                observer.collect()
+                local_collector.collect()
             });
         },
         vec![1, 10, 100, 1000, 10000],
@@ -43,7 +43,7 @@ fn trace_wide_bench(c: &mut Criterion) {
                 {
                     let (root_scope, collector) = Scope::root("root");
 
-                    let _sg = root_scope.attach_and_observe();
+                    let _sg = root_scope.enter();
 
                     if *len > 1 {
                         dummy_iter(*len);
@@ -63,9 +63,9 @@ fn trace_deep_raw_bench(c: &mut Criterion) {
         "trace_deep_raw",
         |b, len| {
             b.iter(|| {
-                let observer = Observer::attach().unwrap();
+                let local_collector = LocalCollector::start();
                 dummy_rec(*len);
-                observer.collect()
+                local_collector.collect()
             });
         },
         vec![1, 10, 100, 1000, 10000],
@@ -80,7 +80,7 @@ fn trace_deep_bench(c: &mut Criterion) {
                 {
                     let (root_scope, collector) = Scope::root("root");
 
-                    let _sg = root_scope.attach_and_observe();
+                    let _sg = root_scope.enter();
 
                     if *len > 1 {
                         dummy_rec(*len);

--- a/crates/minitrace-macro/src/lib.rs
+++ b/crates/minitrace-macro/src/lib.rs
@@ -53,7 +53,7 @@ pub fn trace(args: TokenStream, item: TokenStream) -> TokenStream {
         #vis #constness #unsafety #asyncness #abi fn #ident<#gen_params>(#params) #return_type
         #where_clause
         {
-            let _guard = Span::start(#event);
+            let _guard = Span::enter(#event);
             #block
         }
     )

--- a/examples/asynchronous.rs
+++ b/examples/asynchronous.rs
@@ -9,7 +9,7 @@ fn parallel_job() -> Vec<tokio::task::JoinHandle<()>> {
     let mut v = Vec::with_capacity(4);
     for i in 0..4 {
         v.push(tokio::spawn(
-            iter_job(i).with_scope(Scope::child_from_local("iter job")),
+            iter_job(i).with_scope(Scope::from_local_parent("iter job")),
         ));
     }
     v
@@ -37,7 +37,7 @@ async fn main() {
 
     let f = async {
         let jhs = {
-            let _s = Span::start("a span").with_property(|| ("a property", "a value".to_owned()));
+            let _s = Span::enter("a span").with_property(|| ("a property", "a value".to_owned()));
             parallel_job()
         };
 

--- a/examples/synchronous.rs
+++ b/examples/synchronous.rs
@@ -7,7 +7,7 @@ use minitrace_jaeger::Reporter as JReporter;
 use minitrace_macro::trace;
 
 fn func1(i: u64) {
-    let _guard = Span::start("func1");
+    let _guard = Span::enter("func1");
     std::thread::sleep(std::time::Duration::from_millis(i));
     func2(i);
 }
@@ -21,9 +21,9 @@ fn main() {
     let spans = {
         let (scope, collector) = Scope::root("root");
 
-        let _scope_guard = scope.attach_and_observe();
+        let _scope_guard = scope.enter();
         let _span_guard =
-            Span::start("a span").with_property(|| ("a property", "a value".to_owned()));
+            Span::enter("a span").with_property(|| ("a property", "a value".to_owned()));
 
         for i in 1..=10 {
             func1(i);

--- a/src/local/local_collector.rs
+++ b/src/local/local_collector.rs
@@ -5,11 +5,11 @@ use crate::span::cycle::{Cycle, DefaultClock};
 use crate::span::RawSpan;
 
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
-pub struct Observer {
-    pub(crate) observer_epoch: usize,
+pub struct LocalCollector {
+    pub(crate) local_collector_epoch: usize,
 }
-impl !Sync for Observer {}
-impl !Send for Observer {}
+impl !Sync for LocalCollector {}
+impl !Send for LocalCollector {}
 
 #[derive(Debug)]
 pub struct RawSpans {
@@ -17,11 +17,15 @@ pub struct RawSpans {
     pub end_time: Cycle,
 }
 
-impl Observer {
-    pub fn attach() -> Option<Self> {
+impl LocalCollector {
+    pub fn start() -> Self {
+        Self::try_start().expect("Current thread is occupied by another local collector")
+    }
+
+    pub fn try_start() -> Option<Self> {
         SPAN_LINE.with(|span_line| {
             let s = &mut *span_line.borrow_mut();
-            s.register_observer()
+            s.register_local_collector()
         })
     }
 

--- a/src/local/mod.rs
+++ b/src/local/mod.rs
@@ -1,6 +1,6 @@
 // Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
 
-pub mod observer;
+pub mod local_collector;
 pub mod scope_guard;
 pub mod span_guard;
 pub mod span_line;

--- a/src/local/span_line.rs
+++ b/src/local/span_line.rs
@@ -2,8 +2,7 @@
 
 use std::cell::RefCell;
 
-use crate::local::observer::Observer;
-
+use crate::local::local_collector::LocalCollector;
 use crate::span::span_queue::{SpanHandle, SpanQueue};
 use crate::span::RawSpan;
 
@@ -14,8 +13,13 @@ thread_local! {
 pub struct SpanLine {
     span_queue: SpanQueue,
 
-    observer_existing: bool,
-    current_observer_epoch: usize,
+    local_collector_existing: bool,
+    current_local_collector_epoch: usize,
+}
+
+pub struct LocalSpanHandle {
+    span_handle: SpanHandle,
+    local_collector_epoch: usize,
 }
 
 impl SpanLine {
@@ -23,79 +27,85 @@ impl SpanLine {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             span_queue: SpanQueue::with_capacity(capacity),
-            observer_existing: false,
-            current_observer_epoch: 0,
+            local_collector_existing: false,
+            current_local_collector_epoch: 0,
         }
     }
 
     #[inline]
-    pub fn start_span(&mut self, event: &'static str) -> Option<SpanHandle> {
-        if !self.observer_existing {
+    pub fn enter_span(&mut self, event: &'static str) -> Option<LocalSpanHandle> {
+        if !self.local_collector_existing {
             return None;
         }
 
-        Some(
-            self.span_queue
-                .start_span(event, self.current_observer_epoch),
-        )
-    }
-
-    #[inline]
-    pub fn finish_span(&mut self, span_handle: SpanHandle) {
-        if self.is_valid(&span_handle) {
-            self.span_queue.finish_span(span_handle);
-        }
-    }
-
-    #[inline]
-    pub fn register_observer(&mut self) -> Option<Observer> {
-        // Only allow one observer per thread
-        if self.observer_existing {
-            return None;
-        }
-
-        self.observer_existing = true;
-        self.current_observer_epoch = self.current_observer_epoch.wrapping_add(1);
-
-        Some(Observer {
-            observer_epoch: self.current_observer_epoch,
+        Some(LocalSpanHandle {
+            span_handle: self.span_queue.start_span(event),
+            local_collector_epoch: self.current_local_collector_epoch,
         })
     }
 
-    pub fn unregister_and_collect(&mut self, observer: Observer) -> Vec<RawSpan> {
-        debug_assert!(self.observer_existing);
-        debug_assert_eq!(observer.observer_epoch, self.current_observer_epoch);
+    #[inline]
+    pub fn exit_span(&mut self, local_span_handle: LocalSpanHandle) {
+        if self.is_valid(&local_span_handle) {
+            self.span_queue.finish_span(local_span_handle.span_handle);
+        }
+    }
 
-        self.observer_existing = false;
+    #[inline]
+    pub fn register_local_collector(&mut self) -> Option<LocalCollector> {
+        // Only allow one local collector per thread
+        if self.local_collector_existing {
+            return None;
+        }
+
+        self.local_collector_existing = true;
+        self.current_local_collector_epoch = self.current_local_collector_epoch.wrapping_add(1);
+
+        Some(LocalCollector {
+            local_collector_epoch: self.current_local_collector_epoch,
+        })
+    }
+
+    pub fn unregister_and_collect(&mut self, local_collector: LocalCollector) -> Vec<RawSpan> {
+        debug_assert!(self.local_collector_existing);
+        debug_assert_eq!(
+            local_collector.local_collector_epoch,
+            self.current_local_collector_epoch
+        );
+
+        self.local_collector_existing = false;
         self.span_queue.take_queue()
     }
 
     #[inline]
     pub fn add_properties<I: IntoIterator<Item = (&'static str, String)>, F: FnOnce() -> I>(
         &mut self,
-        span_handle: &SpanHandle,
+        local_span_handle: &LocalSpanHandle,
         properties: F,
     ) {
-        if self.is_valid(span_handle) {
-            self.span_queue.add_properties(span_handle, properties);
+        if self.is_valid(local_span_handle) {
+            self.span_queue
+                .add_properties(&local_span_handle.span_handle, properties);
         }
     }
 
     #[inline]
     pub fn add_property<F: FnOnce() -> (&'static str, String)>(
         &mut self,
-        span_handle: &SpanHandle,
+        local_span_handle: &LocalSpanHandle,
         property: F,
     ) {
-        if self.is_valid(span_handle) {
-            self.span_queue.add_property(span_handle, property);
+        if self.is_valid(local_span_handle) {
+            self.span_queue
+                .add_property(&local_span_handle.span_handle, property);
         }
     }
 }
 
 impl SpanLine {
     #[inline]
-    fn is_valid(&self, span_handle: &SpanHandle) -> bool {
-        self.observer_existing && span_handle.observer_epoch == self.current_observer_epoch
+    fn is_valid(&self, local_span_handle: &LocalSpanHandle) -> bool {
+        self.local_collector_existing
+            && local_span_handle.local_collector_epoch == self.current_local_collector_epoch
     }
 }

--- a/src/span/span_queue.rs
+++ b/src/span/span_queue.rs
@@ -9,6 +9,10 @@ pub struct SpanQueue {
     next_parent_id: SpanId,
 }
 
+pub struct SpanHandle {
+    pub(crate) index: usize,
+}
+
 impl SpanQueue {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
@@ -18,7 +22,7 @@ impl SpanQueue {
     }
 
     #[inline]
-    pub fn start_span(&mut self, event: &'static str, observer_epoch: usize) -> SpanHandle {
+    pub fn start_span(&mut self, event: &'static str) -> SpanHandle {
         let span = RawSpan::begin_with(
             DefaultIdGenerator::next_id(),
             self.next_parent_id,
@@ -30,15 +34,13 @@ impl SpanQueue {
         let index = self.span_queue.len();
         self.span_queue.push(span);
 
-        SpanHandle {
-            index,
-            observer_epoch,
-        }
+        SpanHandle { index }
     }
 
     #[inline]
     pub fn finish_span(&mut self, span_handle: SpanHandle) {
         debug_assert!(span_handle.index < self.span_queue.len());
+        debug_assert_eq!(self.next_parent_id, self.span_queue[span_handle.index].id);
 
         let span = &mut self.span_queue[span_handle.index];
         span.end_with(DefaultClock::now());
@@ -75,9 +77,4 @@ impl SpanQueue {
         self.next_parent_id = SpanId::new(0);
         self.span_queue.split_off(0)
     }
-}
-
-pub struct SpanHandle {
-    pub(crate) index: usize,
-    pub(crate) observer_epoch: usize,
 }

--- a/src/trace/acquirer.rs
+++ b/src/trace/acquirer.rs
@@ -5,7 +5,7 @@ use crossbeam::channel::Sender;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use crate::local::observer::RawSpans;
+use crate::local::local_collector::RawSpans;
 
 use crate::span::span_id::SpanId;
 use crate::span::RawSpan;

--- a/src/trace/span.rs
+++ b/src/trace/span.rs
@@ -3,7 +3,7 @@
 use crate::{LocalSpanGuard, Span};
 
 impl Span {
-    pub fn start(event: &'static str) -> LocalSpanGuard {
-        LocalSpanGuard::start(event)
+    pub fn enter(event: &'static str) -> LocalSpanGuard {
+        LocalSpanGuard::new(event)
     }
 }


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

- Rename: 
  - `Observer` -> `LocalCollector`
  - `Span::start` -> `Span::enter`
  - `Scope::attach_and_observe` -> `Scope::enter`
  - `Scope::merge` -> `Scope::from_parents`

- Remove:
  - `Scope::attach`