### PR TITLE
Fix trace_async macro async_trait usage of in_local_span

### DIFF
--- a/crates/minitrace-macro/src/lib.rs
+++ b/crates/minitrace-macro/src/lib.rs
@@ -101,7 +101,7 @@ pub fn trace_async(args: TokenStream, item: TokenStream) -> TokenStream {
         // hack for `async_trait`
         // See https://docs.rs/async-trait/0.1.31/async_trait/
         quote::quote_spanned! {block.span() =>
-            std::boxed::Box::pin(#block.in_span(#event))
+            std::boxed::Box::pin(#block.in_local_span(#event))
         }
     };
 

--- a/crates/minitrace-macro/src/lib.rs
+++ b/crates/minitrace-macro/src/lib.rs
@@ -101,7 +101,7 @@ pub fn trace_async(args: TokenStream, item: TokenStream) -> TokenStream {
         // hack for `async_trait`
         // See https://docs.rs/async-trait/0.1.31/async_trait/
         quote::quote_spanned! {block.span() =>
-            std::boxed::Box::pin(#block.in_local_span(#event))
+            std::boxed::Box::pin(#block.in_span(#event))
         }
     };
 

--- a/crates/minitrace-macro/src/lib.rs
+++ b/crates/minitrace-macro/src/lib.rs
@@ -101,7 +101,7 @@ pub fn trace_async(args: TokenStream, item: TokenStream) -> TokenStream {
         // hack for `async_trait`
         // See https://docs.rs/async-trait/0.1.31/async_trait/
         quote::quote_spanned! {block.span() =>
-            std::boxed::Box::pin(#block.in_new_span(#event))
+            std::boxed::Box::pin(#block.in_local_span(#event))
         }
     };
 


### PR DESCRIPTION
- Use newly-renamed in_local_span in place of old in_new_span for async_trait hack usage, seems to have just gotten missed in the previous refactor

closes: #64 