### PR TITLE
Move crossbeam to dev-dependencies

### DIFF
--- a/minitrace-macro/src/lib.rs
+++ b/minitrace-macro/src/lib.rs
@@ -550,8 +550,7 @@ fn path_to_string(path: &Path) -> String {
     // some heuristic to prevent too many allocations
     let mut res = String::with_capacity(path.segments.len() * 5);
     for i in 0..path.segments.len() {
-        write!(&mut res, "{}", path.segments[i].ident)
-            .expect("writing to a String should never fail");
+        write!(res, "{}", path.segments[i].ident).expect("writing to a String should never fail");
         if i < path.segments.len() - 1 {
             res.push_str("::");
         }

--- a/minitrace/Cargo.toml
+++ b/minitrace/Cargo.toml
@@ -14,7 +14,6 @@ keywords = ["tracing", "span", "datadog", "jaeger", "opentracing"]
 [dependencies]
 minstant = "0.1"
 minitrace-macro = { path = "../minitrace-macro" }
-crossbeam = "0.8"
 pin-project = "1.0"
 parking_lot = "0.11"
 futures = "0.3"
@@ -25,6 +24,7 @@ retain_mut = "0.1"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
+crossbeam = "0.8"
 minitrace-jaeger = { path = "../minitrace-jaeger" }
 minitrace-datadog = { path = "../minitrace-datadog" }
 tokio = { version = "1.15", features = ["full"] }


### PR DESCRIPTION
I find crossbeam is not used anywhere in the code of minitrace. It seems to only appear in benches and tests. So, I move it to dev-dependencies.