### PR TITLE
Use Ordering::Relaxed for ID allocator

### DIFF
--- a/minitrace/src/collector/global_collector.rs
+++ b/minitrace/src/collector/global_collector.rs
@@ -48,7 +48,7 @@ pub(crate) struct GlobalCollect;
 #[cfg_attr(test, mockall::automock)]
 impl GlobalCollect {
     pub fn start_collect(&self, collect_args: CollectArgs) -> u32 {
-        let collect_id = NEXT_COLLECT_ID.fetch_add(1, Ordering::AcqRel);
+        let collect_id = NEXT_COLLECT_ID.fetch_add(1, Ordering::Relaxed);
         send_command(CollectCommand::StartCollect(StartCollect {
             collect_id,
             collect_args,

--- a/minitrace/src/local/span_id.rs
+++ b/minitrace/src/local/span_id.rs
@@ -16,7 +16,7 @@ pub struct DefaultIdGenerator;
 
 static NEXT_ID_PREFIX: AtomicU16 = AtomicU16::new(0);
 fn next_id_prefix() -> u16 {
-    NEXT_ID_PREFIX.fetch_add(1, Ordering::AcqRel)
+    NEXT_ID_PREFIX.fetch_add(1, Ordering::Relaxed)
 }
 
 thread_local! {


### PR DESCRIPTION
As an ID allocator, the only thing we need is atomicity. As there is no reader or writer accessing the allocator, using `Relaxed` for `fetch_add` is enough.