### PR TITLE
Fix: #[trace] async fn a(mut b)

### DIFF
--- a/minitrace-macro/src/lib.rs
+++ b/minitrace-macro/src/lib.rs
@@ -265,7 +265,6 @@ fn transform_sig(sig: &mut Signature, has_self: bool, is_local: bool) {
             FnArg::Typed(arg) => {
                 if let Pat::Ident(ident) = &mut *arg.pat {
                     ident.by_ref = None;
-                    ident.mutability = None;
                 } else {
                     let positional = positional_arg(i, &arg.pat);
                     let m = mut_pat(&mut arg.pat);


### PR DESCRIPTION
Close issue #112.
Per the comment of @andylokandy this appears to be a residual
carried over from the async-trait crate code.

Signed-off-by: Mark Van de Vyver <mark@taqtiqa.com>