### PR TITLE
feat: support event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Rename `SpanRecord.event` to `SpanRecord.name`.
+- Add `Event` type to represent single points in time during the span's lifetime.
+- Add `Event` support to minitrace-jaeger reporter.
+
 ## v0.4.0
 
 - Remove `LocalSpanGuard` and merge it into `LocalSpan`.

--- a/minitrace-datadog/src/lib.rs
+++ b/minitrace-datadog/src/lib.rs
@@ -65,7 +65,7 @@ pub fn encode(
     spans: &[SpanRecord],
 ) -> Result<Vec<u8>, Box<dyn Error + Send + Sync + 'static>> {
     let spans = spans.iter().map(|s| MPSpan {
-        name: s.event,
+        name: s.name,
         service: service_name,
         trace_type,
         resource,

--- a/minitrace-macro/src/lib.rs
+++ b/minitrace-macro/src/lib.rs
@@ -23,7 +23,7 @@ use syn::Ident;
 use syn::*;
 
 struct Args {
-    event: String,
+    name: String,
     enter_on_poll: bool,
 }
 
@@ -52,7 +52,7 @@ impl Args {
         }
 
         Args {
-            event: name,
+            name,
             enter_on_poll,
         }
     }
@@ -139,7 +139,7 @@ pub fn trace(
 
 /// Instrument a block
 fn gen_block(block: &Block, async_context: bool, args: Args) -> proc_macro2::TokenStream {
-    let event = args.event;
+    let name = args.name;
 
     // Generate the instrumented function body.
     // If the function is an `async fn`, this will wrap it in an async block.
@@ -149,14 +149,14 @@ fn gen_block(block: &Block, async_context: bool, args: Args) -> proc_macro2::Tok
             quote_spanned!(block.span()=>
                 minitrace::future::FutureExt::enter_on_poll(
                     async move { #block },
-                    #event
+                    #name
                 )
             )
         } else {
             quote_spanned!(block.span()=>
                 minitrace::future::FutureExt::in_span(
                     async move { #block },
-                    minitrace::Span::enter_with_local_parent( #event )
+                    minitrace::Span::enter_with_local_parent( #name )
                 )
             )
         }
@@ -166,7 +166,7 @@ fn gen_block(block: &Block, async_context: bool, args: Args) -> proc_macro2::Tok
         }
 
         quote_spanned!(block.span()=>
-            let __guard = minitrace::local::LocalSpan::enter_with_local_parent( #event );
+            let __guard = minitrace::local::LocalSpan::enter_with_local_parent( #name );
             #block
         )
     }

--- a/minitrace/examples/log.rs
+++ b/minitrace/examples/log.rs
@@ -6,13 +6,15 @@ use std::net::SocketAddr;
 use futures::executor::block_on;
 use log::info;
 use minitrace::prelude::*;
+use minitrace::Event;
 
 fn main() {
     env_logger::Builder::from_default_env()
         .format(|buf, record| {
-            // Add a local span to represent the log record
-            let mut span = LocalSpan::enter_with_local_parent(record.level().as_str());
-            span.add_property(|| ("message", record.args().to_string()));
+            // Add a event to the current local span representing the log record
+            Event::add_to_local_parent(record.level().as_str(), || {
+                [("message", record.args().to_string())]
+            });
 
             // Output the log to stdout as usual
             writeln!(buf, "[{}] {}", record.level(), record.args())
@@ -35,17 +37,9 @@ fn main() {
 
     let spans = block_on(collector.collect());
 
-    const TRACE_ID: u64 = 42;
-    const SPAN_ID_PREFIX: u32 = 42;
-    const ROOT_PARENT_SPAN_ID: u64 = 0;
-    let bytes = minitrace_jaeger::encode(
-        String::from("service name"),
-        TRACE_ID,
-        ROOT_PARENT_SPAN_ID,
-        SPAN_ID_PREFIX,
-        &spans,
-    )
-    .expect("encode error");
+    let bytes =
+        minitrace_jaeger::encode(String::from("service name"), rand::random(), 0, 0, &spans)
+            .expect("encode error");
 
     let socket = SocketAddr::new("127.0.0.1".parse().unwrap(), 6831);
     minitrace_jaeger::report_blocking(socket, &bytes).expect("report error");

--- a/minitrace/src/collector/global_collector.rs
+++ b/minitrace/src/collector/global_collector.rs
@@ -375,8 +375,8 @@ fn mount_events(records: &mut [SpanRecord], mut events: HashMap<SpanId, Vec<Even
     if events.is_empty() {
         return;
     }
-    for record in records.iter_mut() {
 
+    for record in records.iter_mut() {
         if let Some(event) = events.remove(&SpanId(record.id)) {
             if record.events.is_empty() {
                 record.events = event;

--- a/minitrace/src/collector/global_collector.rs
+++ b/minitrace/src/collector/global_collector.rs
@@ -373,6 +373,10 @@ fn amend_span(
 
 fn mount_events(records: &mut [SpanRecord], mut events: HashMap<SpanId, Vec<EventRecord>>) {
     for record in records.iter_mut() {
+        if events.is_empty() {
+            return;
+        }
+
         if let Some(event) = events.remove(&SpanId(record.id)) {
             if record.events.is_empty() {
                 record.events = event;

--- a/minitrace/src/collector/global_collector.rs
+++ b/minitrace/src/collector/global_collector.rs
@@ -372,10 +372,10 @@ fn amend_span(
 }
 
 fn mount_events(records: &mut [SpanRecord], mut events: HashMap<SpanId, Vec<EventRecord>>) {
+    if events.is_empty() {
+        return;
+    }
     for record in records.iter_mut() {
-        if events.is_empty() {
-            return;
-        }
 
         if let Some(event) = events.remove(&SpanId(record.id)) {
             if record.events.is_empty() {

--- a/minitrace/src/collector/mod.rs
+++ b/minitrace/src/collector/mod.rs
@@ -34,7 +34,16 @@ pub struct SpanRecord {
     pub parent_id: u32,
     pub begin_unix_time_ns: u64,
     pub duration_ns: u64,
-    pub event: &'static str,
+    pub name: &'static str,
+    pub properties: Vec<(&'static str, String)>,
+    pub events: Vec<EventRecord>,
+}
+
+/// A span record been collected.
+#[derive(Clone, Debug, Default)]
+pub struct EventRecord {
+    pub name: &'static str,
+    pub timestamp_unix_ns: u64,
     pub properties: Vec<(&'static str, String)>,
 }
 
@@ -157,7 +166,7 @@ mod tests {
             .with(predicate::eq(42_u32))
             .return_const(vec![SpanRecord {
                 id: 9527,
-                event: "span",
+                name: "span",
                 ..SpanRecord::default()
             }]);
         mock.expect_submit_spans().times(0);
@@ -172,7 +181,7 @@ mod tests {
         let spans = block_on(collector.collect());
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].id, 9527);
-        assert_eq!(spans[0].event, "span");
+        assert_eq!(spans[0].name, "span");
     }
 
     #[test]

--- a/minitrace/src/event.rs
+++ b/minitrace/src/event.rs
@@ -1,0 +1,42 @@
+// Copyright 2023 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::rc::Rc;
+
+use crate::local::local_span_stack::LOCAL_SPAN_STACK;
+use crate::Span;
+
+/// `Event`s represent single points in time where something occurred during the execution of a program.
+///
+/// An `Event` can be compared to a log record in unstructured logging, but with two key differences:
+///
+/// - `Event`s exist within the context of a span. Unlike log lines, they may be located within the trace tree,
+///   allowing visibility into the temporal context in which the event occurred, as well as the source code location.
+/// - Like spans, Events have structured key-value data known as properties, which may include textual message.
+pub struct Event;
+
+impl Event {
+    /// Add an event to the parent span.
+    pub fn add_to_parent<I, F>(name: &'static str, parent: &Span, properties: F)
+    where
+        I: IntoIterator<Item = (&'static str, String)>,
+        F: FnOnce() -> I,
+    {
+        let mut span = Span::enter_with_parent(name, parent);
+        span.add_properties(properties);
+        if let Some(mut inner) = span.inner.take() {
+            inner.raw_span.is_event = true;
+            inner.submit_spans();
+        }
+    }
+
+    /// Add an event to the current local parent span.
+    pub fn add_to_local_parent<I, F>(name: &'static str, properties: F)
+    where
+        I: IntoIterator<Item = (&'static str, String)>,
+        F: FnOnce() -> I,
+    {
+        let stack = LOCAL_SPAN_STACK.with(Rc::clone);
+        let mut stack = stack.borrow_mut();
+        stack.add_event(name, properties);
+    }
+}

--- a/minitrace/src/future.rs
+++ b/minitrace/src/future.rs
@@ -90,8 +90,8 @@ pub trait FutureExt: std::future::Future + Sized {
     ///
     /// [`Future::poll()`]:(std::future::Future::poll)
     #[inline]
-    fn enter_on_poll(self, event: &'static str) -> EnterOnPoll<Self> {
-        EnterOnPoll { inner: self, event }
+    fn enter_on_poll(self, name: &'static str) -> EnterOnPoll<Self> {
+        EnterOnPoll { inner: self, name }
     }
 }
 
@@ -127,7 +127,7 @@ impl<T: std::future::Future> std::future::Future for InSpan<T> {
 pub struct EnterOnPoll<T> {
     #[pin]
     inner: T,
-    event: &'static str,
+    name: &'static str,
 }
 
 impl<T: std::future::Future> std::future::Future for EnterOnPoll<T> {
@@ -135,7 +135,7 @@ impl<T: std::future::Future> std::future::Future for EnterOnPoll<T> {
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
-        let _guard = LocalSpan::enter_with_local_parent(this.event);
+        let _guard = LocalSpan::enter_with_local_parent(this.name);
         this.inner.poll(cx)
     }
 }

--- a/minitrace/src/lib.rs
+++ b/minitrace/src/lib.rs
@@ -38,16 +38,18 @@
 //!   //         parent_id: 0,
 //!   //         begin_unix_time_ns: 1642166520139678013,
 //!   //         duration_ns: 16008,
-//!   //         event: "root",
+//!   //         name: "root",
 //!   //         properties: [],
+//!   //         events: [],
 //!   //     },
 //!   //     SpanRecord {
 //!   //         id: 2,
 //!   //         parent_id: 1,
 //!   //         begin_unix_time_ns: 1642166520139692070,
 //!   //         duration_ns: 634,
-//!   //         event: "a child span",
+//!   //         name: "a child span",
 //!   //         properties: [],
+//!   //         events: [],
 //!   //     },
 //!   // ]
 //!   ```
@@ -93,24 +95,27 @@
 //!   //         parent_id: 0,
 //!   //         begin_unix_time_ns: 1643101008017429580,
 //!   //         duration_ns: 64132,
-//!   //         event: "root",
+//!   //         name: "root",
 //!   //         properties: [],
+//!   //         events: [],
 //!   //     },
 //!   //     SpanRecord {
 //!   //         id: 2,
 //!   //         parent_id: 1,
 //!   //         begin_unix_time_ns: 1643101008017486383,
 //!   //         duration_ns: 4150,
-//!   //         event: "a child span",
+//!   //         name: "a child span",
 //!   //         properties: [],
+//!   //         events: [],
 //!   //     },
 //!   //     SpanRecord {
 //!   //         id: 3,
 //!   //         parent_id: 2,
 //!   //         begin_unix_time_ns: 1643101008017488703,
 //!   //         duration_ns: 1318,
-//!   //         event: "a child span of child span",
+//!   //         name: "a child span of child span",
 //!   //         properties: [],
+//!   //         events: [],
 //!   //     },
 //!   // ]
 //!   ```
@@ -144,25 +149,91 @@
 //!   //         parent_id: 0,
 //!   //         begin_unix_time_ns: 1642166791041022255,
 //!   //         duration_ns: 121705,
-//!   //         event: "root",
+//!   //         name: "root",
 //!   //         properties: [
 //!   //             (
 //!   //                 "key",
 //!   //                 "value",
 //!   //             ),
 //!   //         ],
+//!   //         events: [],
 //!   //     },
 //!   //     SpanRecord {
 //!   //         id: 2,
 //!   //         parent_id: 1,
 //!   //         begin_unix_time_ns: 1642166791041132550,
 //!   //         duration_ns: 7724,
-//!   //         event: "a child span",
+//!   //         name: "a child span",
 //!   //         properties: [
 //!   //             (
 //!   //                 "key",
 //!   //                 "value",
 //!   //             ),
+//!   //         ],
+//!   //         events: [],
+//!   //     },
+//!   // ]
+//!   ```
+//!
+//!
+//! ## Event
+//!
+//!   [`Event`] represent single points in time where something occurred during the execution of a program.
+//!   An `Event` can be seen as a log record attached to a span.
+//!
+//!   ```
+//!   use minitrace::prelude::*;
+//!   use futures::executor::block_on;
+//!
+//!   let (mut root, collector) = Span::root("root");
+//!
+//!   Event::add_to_parent("event in root", &root, || []);
+//!
+//!   {
+//!       let _guard = root.set_local_parent();
+//!       let mut span1 = LocalSpan::enter_with_local_parent("a child span");
+//!
+//!       Event::add_to_local_parent("event in span1", || [("key", "value".to_owned())]);
+//!   }
+//!
+//!   drop(root);
+//!   let records: Vec<SpanRecord> = block_on(collector.collect());
+//!
+//!   println!("{records:#?}");
+//!   // [
+//!   //     SpanRecord {
+//!   //         id: 1,
+//!   //         parent_id: 0,
+//!   //         begin_unix_time_ns: 1689321940550848459,
+//!   //         duration_ns: 25708,
+//!   //         name: "root",
+//!   //         properties: [],
+//!   //         events: [
+//!   //             EventRecord {
+//!   //                 name: "event in root",
+//!   //                 timestamp_unix_ns: 1689321940550870667,
+//!   //                 properties: [],
+//!   //             },
+//!   //         ],
+//!   //     },
+//!   //     SpanRecord {
+//!   //         id: 3,
+//!   //         parent_id: 1,
+//!   //         begin_unix_time_ns: 1689321940550874167,
+//!   //         duration_ns: 0,
+//!   //         name: "span1",
+//!   //         properties: [],
+//!   //         events: [
+//!   //             EventRecord {
+//!   //                 name: "event in span1",
+//!   //                 timestamp_unix_ns: 1689321940550874167,
+//!   //                 properties: [
+//!   //                     (
+//!   //                         "key",
+//!   //                         "value",
+//!   //                     ),
+//!   //                 ],
+//!   //             },
 //!   //         ],
 //!   //     },
 //!   // ]
@@ -206,7 +277,7 @@
 //!   //         parent_id: 0,
 //!   //         begin_unix_time_ns: 1642167988459480418,
 //!   //         duration_ns: 200741472,
-//!   //         event: "root",
+//!   //         name: "root",
 //!   //         properties: [],
 //!   //     },
 //!   //     SpanRecord {
@@ -214,7 +285,7 @@
 //!   //         parent_id: 1,
 //!   //         begin_unix_time_ns: 1642167988459571971,
 //!   //         duration_ns: 100084126,
-//!   //         event: "do_something",
+//!   //         name: "do_something",
 //!   //         properties: [],
 //!   //     },
 //!   //     SpanRecord {
@@ -222,7 +293,7 @@
 //!   //         parent_id: 1,
 //!   //         begin_unix_time_ns: 1642167988559887219,
 //!   //         duration_ns: 100306947,
-//!   //         event: "do_something_async",
+//!   //         name: "do_something_async",
 //!   //         properties: [],
 //!   //     },
 //!   // ]
@@ -245,6 +316,7 @@
 #![allow(clippy::arc_with_non_send_sync)]
 
 pub mod collector;
+mod event;
 pub mod future;
 pub mod local;
 mod span;
@@ -307,6 +379,7 @@ pub mod util;
 /// [`in_span()`]: crate::future::FutureExt::in_span
 pub use minitrace_macro::trace;
 
+pub use crate::event::Event;
 pub use crate::span::Span;
 
 pub mod prelude {
@@ -317,6 +390,8 @@ pub mod prelude {
     pub use crate::collector::Collector;
     #[doc(no_inline)]
     pub use crate::collector::SpanRecord;
+    #[doc(no_inline)]
+    pub use crate::event::Event;
     #[doc(no_inline)]
     pub use crate::future::FutureExt as _;
     #[doc(no_inline)]

--- a/minitrace/src/local/local_span.rs
+++ b/minitrace/src/local/local_span.rs
@@ -19,9 +19,9 @@ struct LocalSpanInner {
 
 impl LocalSpan {
     #[inline]
-    pub fn enter_with_local_parent(event: &'static str) -> Self {
+    pub fn enter_with_local_parent(name: &'static str) -> Self {
         let stack = LOCAL_SPAN_STACK.with(Rc::clone);
-        Self::enter_with_stack(event, stack)
+        Self::enter_with_stack(name, stack)
     }
 
     #[inline]
@@ -41,15 +41,14 @@ impl LocalSpan {
             span_stack.add_properties(span_handle, properties);
         }
     }
+}
 
+impl LocalSpan {
     #[inline]
-    pub(crate) fn enter_with_stack(
-        event: &'static str,
-        stack: Rc<RefCell<LocalSpanStack>>,
-    ) -> Self {
+    pub(crate) fn enter_with_stack(name: &'static str, stack: Rc<RefCell<LocalSpanStack>>) -> Self {
         let span_handle = {
             let mut stack = stack.borrow_mut();
-            stack.enter_span(event)
+            stack.enter_span(name)
         };
 
         let inner = span_handle.map(|span_handle| LocalSpanInner { stack, span_handle });

--- a/minitrace/src/local/local_span_line.rs
+++ b/minitrace/src/local/local_span_line.rs
@@ -31,9 +31,9 @@ impl SpanLine {
     }
 
     #[inline]
-    pub fn start_span(&mut self, event: &'static str) -> Option<LocalSpanHandle> {
+    pub fn start_span(&mut self, name: &'static str) -> Option<LocalSpanHandle> {
         Some(LocalSpanHandle {
-            span_handle: self.span_queue.start_span(event)?,
+            span_handle: self.span_queue.start_span(name)?,
             span_line_epoch: self.epoch,
         })
     }
@@ -43,6 +43,15 @@ impl SpanLine {
         if self.epoch == handle.span_line_epoch {
             self.span_queue.finish_span(handle.span_handle);
         }
+    }
+
+    #[inline]
+    pub fn add_event<I, F>(&mut self, name: &'static str, properties: F)
+    where
+        I: IntoIterator<Item = (&'static str, String)>,
+        F: FnOnce() -> I,
+    {
+        self.span_queue.add_event(name, properties);
     }
 
     #[inline]

--- a/minitrace/src/local/local_span_stack.rs
+++ b/minitrace/src/local/local_span_stack.rs
@@ -32,9 +32,9 @@ impl LocalSpanStack {
     }
 
     #[inline]
-    pub fn enter_span(&mut self, event: &'static str) -> Option<LocalSpanHandle> {
+    pub fn enter_span(&mut self, name: &'static str) -> Option<LocalSpanHandle> {
         let span_line = self.current_span_line()?;
-        span_line.start_span(event)
+        span_line.start_span(name)
     }
 
     #[inline]
@@ -45,6 +45,17 @@ impl LocalSpanStack {
                 local_span_handle.span_line_epoch
             );
             span_line.finish_span(local_span_handle);
+        }
+    }
+
+    #[inline]
+    pub fn add_event<I, F>(&mut self, name: &'static str, properties: F)
+    where
+        I: IntoIterator<Item = (&'static str, String)>,
+        F: FnOnce() -> I,
+    {
+        if let Some(span_line) = self.current_span_line() {
+            span_line.add_event(name, properties);
         }
     }
 

--- a/minitrace/src/local/raw_span.rs
+++ b/minitrace/src/local/raw_span.rs
@@ -9,8 +9,9 @@ pub struct RawSpan {
     pub id: SpanId,
     pub parent_id: SpanId,
     pub begin_instant: Instant,
-    pub event: &'static str,
+    pub name: &'static str,
     pub properties: Vec<(&'static str, String)>,
+    pub is_event: bool,
 
     // Will write this field at post processing
     pub end_instant: Instant,
@@ -22,14 +23,16 @@ impl RawSpan {
         id: SpanId,
         parent_id: SpanId,
         begin_instant: Instant,
-        event: &'static str,
+        name: &'static str,
+        is_event: bool,
     ) -> Self {
         RawSpan {
             id,
             parent_id,
             begin_instant,
-            event,
+            name,
             properties: vec![],
+            is_event,
             end_instant: begin_instant,
         }
     }

--- a/minitrace/src/util/tree.rs
+++ b/minitrace/src/util/tree.rs
@@ -14,7 +14,7 @@ use crate::util::RawSpans;
 
 #[derive(Debug, PartialOrd, PartialEq, Ord, Eq)]
 pub struct Tree {
-    event: &'static str,
+    name: &'static str,
     children: Vec<Tree>,
     properties: Vec<(&'static str, String)>,
 }
@@ -31,7 +31,7 @@ impl Tree {
             f,
             "{:indent$}{} {:?}",
             "",
-            self.event,
+            self.name,
             self.properties,
             indent = depth * 4
         )?;
@@ -57,7 +57,7 @@ impl Tree {
         let spans = raw_spans.into_inner().1;
         children.insert(SpanId::default(), ("", vec![], vec![]));
         for span in &spans {
-            children.insert(span.id, (span.event, vec![], span.properties.clone()));
+            children.insert(span.id, (span.name, vec![], span.properties.clone()));
         }
         for span in &spans {
             children
@@ -90,14 +90,14 @@ impl Tree {
                         collect
                             .entry(item.collect_id)
                             .or_default()
-                            .insert(span.id, (span.event, vec![], span.properties.clone()));
+                            .insert(span.id, (span.name, vec![], span.properties.clone()));
                     }
                     SpanSet::LocalSpans(spans) => {
                         for span in spans.spans.iter() {
                             collect
                                 .entry(item.collect_id)
                                 .or_default()
-                                .insert(span.id, (span.event, vec![], span.properties.clone()));
+                                .insert(span.id, (span.name, vec![], span.properties.clone()));
                         }
                     }
                     SpanSet::SharedLocalSpans(spans) => {
@@ -105,7 +105,7 @@ impl Tree {
                             collect
                                 .entry(item.collect_id)
                                 .or_default()
-                                .insert(span.id, (span.event, vec![], span.properties.clone()));
+                                .insert(span.id, (span.name, vec![], span.properties.clone()));
                         }
                     }
                 }
@@ -191,7 +191,7 @@ impl Tree {
         for span in &span_records {
             children.insert(
                 SpanId::new(span.id),
-                (span.event, vec![], span.properties.clone()),
+                (span.name, vec![], span.properties.clone()),
             );
         }
         for span in &span_records {
@@ -214,9 +214,9 @@ impl Tree {
         id: SpanId,
         raw: &mut HashMap<SpanId, (&'static str, Vec<SpanId>, Vec<(&'static str, String)>)>,
     ) -> Tree {
-        let (event, children, properties) = raw.get(&id).cloned().unwrap();
+        let (name, children, properties) = raw.get(&id).cloned().unwrap();
         Tree {
-            event,
+            name,
             children: children
                 .into_iter()
                 .map(|id| Self::build_tree(id, raw))


### PR DESCRIPTION
Signed-off-by: Andy Lok <andylokandy@hotmail.com>

- Rename `SpanRecord.event` to `SpanRecord.name`.
- Add `Event` type to represent single points in time during the span's lifetime.
- Add `Event` support to minitrace-jaeger reporter.
