### PR TITLE
chore(dependencies): update `opentelemetry` to latest version

### DIFF
--- a/minitrace-opentelemetry/Cargo.toml
+++ b/minitrace-opentelemetry/Cargo.toml
@@ -16,9 +16,10 @@ keywords = ["tracing", "span", "datadog", "jaeger", "opentelemetry"]
 futures = { version = "0.3", features = ["executor"] }
 log = "0.4"
 minitrace = { version = "0.6.2", path = "../minitrace" }
-opentelemetry = { version = "0.20", features = ["trace"] }
+opentelemetry = { version = "0.21", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21", features = ["trace"] }
 
 [dev-dependencies]
-opentelemetry-otlp = { version = "0.13", features = ["trace"] }
+opentelemetry-otlp = { version = "0.14", features = ["trace"] }
 rand = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/minitrace/Cargo.toml
+++ b/minitrace/Cargo.toml
@@ -42,8 +42,9 @@ minitrace-jaeger = { version = "0.6.2", path = "../minitrace-jaeger" }
 minitrace-opentelemetry = { version = "0.6.2", path = "../minitrace-opentelemetry" }
 mockall = "0.11"
 once_cell = "1"
-opentelemetry = { version = "0.20", features = ["trace"] }
-opentelemetry-otlp = { version = "0.13", features = ["trace"] }
+opentelemetry = { version = "0.21", features = ["trace"] }
+opentelemetry-otlp = { version = "0.14", features = ["trace"] }
+opentelemetry_sdk = { version = "0.21" }
 rand = "0.8"
 rustracing = "0.6"
 serial_test = "2"

--- a/minitrace/examples/asynchronous.rs
+++ b/minitrace/examples/asynchronous.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use minitrace::collector::Config;
 use minitrace::collector::Reporter;
 use minitrace::prelude::*;
+use opentelemetry_otlp::WithExportConfig;
 
 fn parallel_job() -> Vec<tokio::task::JoinHandle<()>> {
     let mut v = Vec::with_capacity(4);
@@ -85,19 +86,17 @@ impl ReportAll {
                 "select",
             ),
             opentelemetry: minitrace_opentelemetry::OpenTelemetryReporter::new(
-                opentelemetry_otlp::SpanExporter::new_tonic(
-                    opentelemetry_otlp::ExportConfig {
-                        endpoint: "http://127.0.0.1:4317".to_string(),
-                        protocol: opentelemetry_otlp::Protocol::Grpc,
-                        timeout: Duration::from_secs(
-                            opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
-                        ),
-                    },
-                    opentelemetry_otlp::TonicConfig::default(),
-                )
-                .expect("initialize oltp exporter"),
+                opentelemetry_otlp::new_exporter()
+                    .tonic()
+                    .with_endpoint("http://127.0.0.1:4317".to_string())
+                    .with_protocol(opentelemetry_otlp::Protocol::Grpc)
+                    .with_timeout(Duration::from_secs(
+                        opentelemetry_otlp::OTEL_EXPORTER_OTLP_TIMEOUT_DEFAULT,
+                    ))
+                    .build_span_exporter()
+                    .expect("initialize oltp exporter"),
                 opentelemetry::trace::SpanKind::Server,
-                Cow::Owned(opentelemetry::sdk::Resource::new([
+                Cow::Owned(opentelemetry_sdk::Resource::new([
                     opentelemetry::KeyValue::new("service.name", "asynchronous(opentelemetry)"),
                 ])),
                 opentelemetry::InstrumentationLibrary::new(


### PR DESCRIPTION
Seems like the latest version of `opentelemetry` crates now needs to use `opentelemetry_sdk` instead of `opentelemetry::sdk`, and also some types needs to be modified to support the latest API changes. 
