### PR TITLE
Replace `set_reporter` with `set_collector` and init collector on-demand

### DIFF
--- a/minitrace-datadog/README.md
+++ b/minitrace-datadog/README.md
@@ -28,6 +28,7 @@ cargo run --example synchronous
 use std::net::SocketAddr;
 
 use minitrace::collector::Config;
+use minitrace::collector::GlobalCollector;
 use minitrace::prelude::*;
 
 // Initialize reporter
@@ -37,7 +38,8 @@ let reporter = minitrace_datadog::DatadogReporter::new(
     "db",
     "select",
 );
-minitrace::set_reporter(reporter, Config::default());
+
+minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
 {
     // Start tracing

--- a/minitrace-jaeger/README.md
+++ b/minitrace-jaeger/README.md
@@ -30,13 +30,14 @@ Web UI is available on [http://127.0.0.1:16686/](http://127.0.0.1:16686/)
 use std::net::SocketAddr;
 
 use minitrace::collector::Config;
+use minitrace::collector::GlobalCollector;
 use minitrace::prelude::*;
 
 // Initialize reporter
 let reporter =
     minitrace_jaeger::JaegerReporter::new("127.0.0.1:6831".parse().unwrap(), "asynchronous")
         .unwrap();
-minitrace::set_reporter(reporter, Config::default());
+minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
 {
     // Start tracing

--- a/minitrace-opentelemetry/README.md
+++ b/minitrace-opentelemetry/README.md
@@ -33,6 +33,7 @@ Zipkin UI is available on [http://127.0.0.1:9411/](http://127.0.0.1:9411/)
 use std::borrow::Cow;
 use std::time::Duration;
 use minitrace::collector::Config;
+use minitrace::collector::GlobalCollector;
 use minitrace::prelude::*;
 use minitrace_opentelemetry::OpenTelemetryReporter;
 use opentelemetry_otlp::{SpanExporter, ExportConfig, Protocol, TonicConfig};
@@ -56,7 +57,7 @@ let reporter = OpenTelemetryReporter::new(
     Cow::Owned(Resource::new([KeyValue::new("service.name", "asynchronous")])),
     InstrumentationLibrary::new("example-crate", Some(env!("CARGO_PKG_VERSION")), None::<&'static str>, None),
 );
-minitrace::set_reporter(reporter, Config::default());
+minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
 {
     // Start tracing

--- a/minitrace/benches/compare.rs
+++ b/minitrace/benches/compare.rs
@@ -3,6 +3,7 @@
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use minitrace::collector::GlobalCollector;
 
 fn init_opentelemetry() {
     use tracing_subscriber::prelude::*;
@@ -21,7 +22,10 @@ fn init_minitrace() {
         fn report(&mut self, _spans: &[minitrace::prelude::SpanRecord]) {}
     }
 
-    minitrace::set_reporter(DummyReporter, minitrace::collector::Config::default());
+    minitrace::set_collector(GlobalCollector::new(
+        DummyReporter,
+        minitrace::collector::Config::default(),
+    ));
 }
 
 fn opentelemetry_harness(n: usize) {

--- a/minitrace/benches/trace.rs
+++ b/minitrace/benches/trace.rs
@@ -4,6 +4,7 @@ use criterion::black_box;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use criterion::Criterion;
+use minitrace::collector::GlobalCollector;
 use minitrace::local::LocalCollector;
 use minitrace::prelude::*;
 
@@ -14,7 +15,10 @@ fn init_minitrace() {
         fn report(&mut self, _spans: &[minitrace::prelude::SpanRecord]) {}
     }
 
-    minitrace::set_reporter(DummyReporter, minitrace::collector::Config::default());
+    minitrace::set_collector(GlobalCollector::new(
+        DummyReporter,
+        minitrace::collector::Config::default(),
+    ));
 }
 
 fn dummy_iter(i: usize) {

--- a/minitrace/examples/asynchronous.rs
+++ b/minitrace/examples/asynchronous.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use minitrace::collector::Config;
+use minitrace::collector::GlobalCollector;
 use minitrace::collector::Reporter;
 use minitrace::prelude::*;
 
@@ -37,7 +38,7 @@ async fn other_job() {
 
 #[tokio::main]
 async fn main() {
-    minitrace::set_reporter(ReportAll::new(), Config::default());
+    minitrace::set_collector(GlobalCollector::new(ReportAll::new(), Config::default()));
 
     {
         let parent = SpanContext::random();

--- a/minitrace/examples/get_started.rs
+++ b/minitrace/examples/get_started.rs
@@ -2,10 +2,11 @@
 
 use minitrace::collector::Config;
 use minitrace::collector::ConsoleReporter;
+use minitrace::collector::GlobalCollector;
 use minitrace::prelude::*;
 
 fn main() {
-    minitrace::set_reporter(ConsoleReporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 
     {
         let parent = SpanContext::random();

--- a/minitrace/examples/log.rs
+++ b/minitrace/examples/log.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use log::info;
 use minitrace::collector::Config;
 use minitrace::collector::ConsoleReporter;
+use minitrace::collector::GlobalCollector;
 use minitrace::prelude::*;
 use minitrace::Event;
 
@@ -15,7 +16,7 @@ fn plus(a: u64, b: u64) -> Result<u64, std::io::Error> {
 }
 
 fn main() {
-    minitrace::set_reporter(ConsoleReporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
     env_logger::Builder::from_default_env()
         .format(|buf, record| {
             // Add a event to the current local span representing the log record

--- a/minitrace/examples/synchronous.rs
+++ b/minitrace/examples/synchronous.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 use std::time::Duration;
 
 use minitrace::collector::Config;
+use minitrace::collector::GlobalCollector;
 use minitrace::collector::Reporter;
 use minitrace::prelude::*;
 
@@ -22,7 +23,7 @@ fn func2(i: u64) {
 
 #[tokio::main]
 async fn main() {
-    minitrace::set_reporter(ReportAll::new(), Config::default());
+    minitrace::set_collector(GlobalCollector::new(ReportAll::new(), Config::default()));
 
     {
         let parent = SpanContext::random();

--- a/minitrace/examples/unit_test.rs
+++ b/minitrace/examples/unit_test.rs
@@ -24,13 +24,16 @@ async fn test_async() -> Result<()> {
 mod test_util {
     use minitrace::collector::Config;
     use minitrace::collector::ConsoleReporter;
+    use minitrace::collector::GlobalCollector;
     use minitrace::prelude::*;
 
     use super::*;
 
     pub fn setup_minitrace<F>(test: F)
-    where F: FnOnce() -> Result<()> + 'static {
-        minitrace::set_reporter(ConsoleReporter, Config::default());
+    where
+        F: FnOnce() -> Result<()> + 'static,
+    {
+        minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
         {
             let root = Span::root(closure_name::<F>(), SpanContext::random());
             let _guard = root.set_local_parent();
@@ -44,7 +47,7 @@ mod test_util {
         F: FnOnce() -> Fut + 'static,
         Fut: std::future::Future<Output = Result<()>> + Send + 'static,
     {
-        minitrace::set_reporter(ConsoleReporter, Config::default());
+        minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
         let rt = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(3)
             .enable_all()

--- a/minitrace/src/collector/base.rs
+++ b/minitrace/src/collector/base.rs
@@ -1,0 +1,4 @@
+pub trait Collector: Send {
+    fn start(&self);
+    fn handle_commands(&mut self, flush: bool);
+}

--- a/minitrace/src/collector/mod.rs
+++ b/minitrace/src/collector/mod.rs
@@ -4,6 +4,7 @@
 
 #![cfg_attr(test, allow(dead_code))]
 
+pub(crate) mod base;
 pub(crate) mod command;
 mod console_reporter;
 pub(crate) mod global_collector;
@@ -15,9 +16,11 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub use base::Collector;
 pub use console_reporter::ConsoleReporter;
 #[cfg(not(test))]
 pub(crate) use global_collector::GlobalCollect;
+pub use global_collector::GlobalCollector;
 #[cfg(test)]
 pub(crate) use global_collector::MockGlobalCollect;
 pub use global_collector::Reporter;
@@ -282,9 +285,11 @@ impl Config {
     ///
     /// ```
     /// use minitrace::collector::Config;
+    /// use minitrace::collector::GlobalCollector;
+    /// use minitrace::collector::ConsoleReporter;
     ///
     /// let config = Config::default().max_spans_per_trace(Some(100));
-    /// minitrace::set_reporter(minitrace::collector::ConsoleReporter, config);
+    /// minitrace::set_collector(GlobalCollector::new(ConsoleReporter, config));
     /// ```
     pub fn max_spans_per_trace(self, max_spans_per_trace: Option<usize>) -> Self {
         Self {
@@ -308,9 +313,11 @@ impl Config {
     /// use std::time::Duration;
     ///
     /// use minitrace::collector::Config;
+    /// use minitrace::collector::GlobalCollector;
+    /// use minitrace::collector::ConsoleReporter;
     ///
     /// let config = Config::default().batch_report_interval(Duration::from_secs(1));
-    /// minitrace::set_reporter(minitrace::collector::ConsoleReporter, config);
+    /// minitrace::set_collector(GlobalCollector::new(ConsoleReporter, config));
     /// ```
     pub fn batch_report_interval(self, batch_report_interval: Duration) -> Self {
         Self {
@@ -336,9 +343,11 @@ impl Config {
     /// use std::time::Duration;
     ///
     /// use minitrace::collector::Config;
+    /// use minitrace::collector::GlobalCollector;
+    /// use minitrace::collector::ConsoleReporter;
     ///
     /// let config = Config::default().batch_report_max_spans(Some(200));
-    /// minitrace::set_reporter(minitrace::collector::ConsoleReporter, config);
+    /// minitrace::set_collector(GlobalCollector::new(ConsoleReporter, config));
     /// ```
     pub fn batch_report_max_spans(self, batch_report_max_spans: Option<usize>) -> Self {
         Self {

--- a/minitrace/src/lib.rs
+++ b/minitrace/src/lib.rs
@@ -73,9 +73,10 @@
 //! ```
 //! use minitrace::collector::Config;
 //! use minitrace::collector::ConsoleReporter;
+//! use minitrace::collector::GlobalCollector;
 //!
 //! fn main() {
-//!     minitrace::set_reporter(ConsoleReporter, Config::default());
+//!     minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 //!
 //!     // ...
 //!
@@ -109,9 +110,10 @@
 //! ```
 //! use minitrace::collector::Config;
 //! use minitrace::collector::ConsoleReporter;
+//! use minitrace::collector::GlobalCollector;
 //! use minitrace::prelude::*;
 //!
-//! minitrace::set_reporter(ConsoleReporter, Config::default());
+//! minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 //!
 //! {
 //!     let root_span = Span::root("root", SpanContext::random());
@@ -186,9 +188,10 @@
 //! ```
 //! use minitrace::collector::Config;
 //! use minitrace::collector::ConsoleReporter;
+//! use minitrace::collector::GlobalCollector;
 //! use minitrace::prelude::*;
 //!
-//! minitrace::set_reporter(ConsoleReporter, Config::default());
+//! minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 //!
 //! {
 //!     let root = Span::root("root", SpanContext::random());
@@ -218,9 +221,10 @@
 //! ```
 //! use minitrace::collector::Config;
 //! use minitrace::collector::ConsoleReporter;
+//! use minitrace::collector::GlobalCollector;
 //! use minitrace::prelude::*;
 //!
-//! minitrace::set_reporter(ConsoleReporter, Config::default());
+//! minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 //!
 //! {
 //!     let root = Span::root("root", SpanContext::random());
@@ -250,6 +254,7 @@
 //! use futures::executor::block_on;
 //! use minitrace::collector::Config;
 //! use minitrace::collector::ConsoleReporter;
+//! use minitrace::collector::GlobalCollector;
 //! use minitrace::prelude::*;
 //!
 //! #[trace]
@@ -262,7 +267,7 @@
 //!     futures_timer::Delay::new(std::time::Duration::from_millis(i)).await;
 //! }
 //!
-//! minitrace::set_reporter(ConsoleReporter, Config::default());
+//! minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 //!
 //! {
 //!     let root = Span::root("root", SpanContext::random());
@@ -300,10 +305,10 @@
 //!
 //! use minitrace::collector::Config;
 //! use minitrace::collector::ConsoleReporter;
+//! use minitrace::collector::GlobalCollector;
 //!
-//! minitrace::set_reporter(
-//!     ConsoleReporter,
-//!     Config::default().batch_report_interval(Duration::from_secs(1)),
+//! minitrace::set_collector(
+//!     GlobalCollector::new(ConsoleReporter, Config::default().batch_report_interval(Duration::from_secs(1)))
 //! );
 //!
 //! minitrace::flush();
@@ -369,7 +374,7 @@ pub mod util;
 pub use minitrace_macro::trace;
 
 pub use crate::collector::global_collector::flush;
-pub use crate::collector::global_collector::set_reporter;
+pub use crate::collector::global_collector::set_collector;
 pub use crate::event::Event;
 pub use crate::span::Span;
 

--- a/minitrace/src/span.rs
+++ b/minitrace/src/span.rs
@@ -559,6 +559,7 @@ mod tests {
 
     use super::*;
     use crate::collector::ConsoleReporter;
+    use crate::collector::GlobalCollector;
     use crate::collector::MockGlobalCollect;
     use crate::local::LocalSpan;
     use crate::prelude::TraceId;
@@ -574,7 +575,8 @@ mod tests {
 
     #[test]
     fn root_collect() {
-        crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
+        let collector = GlobalCollector::new(ConsoleReporter, crate::collector::Config::default());
+        crate::set_collector(collector);
 
         let mut mock = MockGlobalCollect::new();
         let mut seq = Sequence::new();
@@ -615,7 +617,8 @@ mod tests {
 
     #[test]
     fn root_cancel() {
-        crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
+        let collector = GlobalCollector::new(ConsoleReporter, crate::collector::Config::default());
+        crate::set_collector(collector);
 
         let mut mock = MockGlobalCollect::new();
         let mut seq = Sequence::new();
@@ -638,7 +641,8 @@ mod tests {
 
     #[test]
     fn span_with_parent() {
-        crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
+        let collector = GlobalCollector::new(ConsoleReporter, crate::collector::Config::default());
+        crate::set_collector(collector);
 
         let routine = |collect| {
             let parent_ctx = SpanContext::random();
@@ -697,7 +701,8 @@ root []
 
     #[test]
     fn span_with_parents() {
-        crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
+        let collector = GlobalCollector::new(ConsoleReporter, crate::collector::Config::default());
+        crate::set_collector(collector);
 
         let routine = |collect: GlobalCollect| {
             let parent_ctx = SpanContext::random();
@@ -789,7 +794,8 @@ parent5 []
 
     #[test]
     fn span_push_child_spans() {
-        crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
+        let collector = GlobalCollector::new(ConsoleReporter, crate::collector::Config::default());
+        crate::set_collector(collector);
 
         let routine = |collect: GlobalCollect| {
             let parent_ctx = SpanContext::random();
@@ -874,7 +880,8 @@ parent5 []
 
     #[test]
     fn span_communicate_via_stack() {
-        crate::set_reporter(ConsoleReporter, crate::collector::Config::default());
+        let collector = GlobalCollector::new(ConsoleReporter, crate::collector::Config::default());
+        crate::set_collector(collector);
 
         let routine = |collect: GlobalCollect| {
             let stack = Rc::new(RefCell::new(LocalSpanStack::with_capacity(16)));

--- a/minitrace/tests/lib.rs
+++ b/minitrace/tests/lib.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use futures::executor::block_on;
 use minitrace::collector::Config;
 use minitrace::collector::ConsoleReporter;
+use minitrace::collector::GlobalCollector;
 use minitrace::collector::TestReporter;
 use minitrace::local::LocalCollector;
 use minitrace::prelude::*;
@@ -40,7 +41,7 @@ fn four_spans() {
 #[serial]
 fn single_thread_single_span() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let root = Span::root("root", SpanContext::random());
@@ -68,7 +69,7 @@ root []
 #[serial]
 fn single_thread_multiple_spans() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let root1 = Span::root("root1", SpanContext::new(TraceId(12), SpanId::default()));
@@ -148,7 +149,7 @@ root3 []
 #[serial]
 fn multiple_threads_single_span() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     crossbeam::scope(|scope| {
         let root = Span::root("root", SpanContext::random());
@@ -205,7 +206,7 @@ root []
 #[serial]
 fn multiple_threads_multiple_spans() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     crossbeam::scope(|scope| {
         let root1 = Span::root("root1", SpanContext::new(TraceId(12), SpanId::default()));
@@ -326,7 +327,7 @@ root2 []
 #[serial]
 fn multiple_spans_without_local_spans() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let root1 = Span::root("root1", SpanContext::new(TraceId(12), SpanId::default()));
@@ -423,7 +424,7 @@ fn test_macro() {
     }
 
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let root = Span::root("root", SpanContext::random());
@@ -500,7 +501,7 @@ fn macro_example() {
     }
 
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let root = Span::root("root", SpanContext::random());
@@ -530,7 +531,7 @@ root []
 #[serial]
 fn multiple_local_parent() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let root = Span::root("root", SpanContext::random());
@@ -563,7 +564,7 @@ root []
 #[serial]
 fn early_local_collect() {
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(reporter, Config::default()));
 
     {
         let local_collector = LocalCollector::start();
@@ -600,7 +601,10 @@ fn max_spans_per_trace() {
     }
 
     let (reporter, collected_spans) = TestReporter::new();
-    minitrace::set_reporter(reporter, Config::default().max_spans_per_trace(Some(5)));
+    minitrace::set_collector(GlobalCollector::new(
+        reporter,
+        Config::default().max_spans_per_trace(Some(5)),
+    ));
 
     {
         let root = Span::root("root", SpanContext::random());
@@ -643,7 +647,7 @@ root []
 #[test]
 #[serial]
 fn test_elapsed() {
-    minitrace::set_reporter(ConsoleReporter, Config::default());
+    minitrace::set_collector(GlobalCollector::new(ConsoleReporter, Config::default()));
 
     {
         let root = Span::root("root", SpanContext::random());

--- a/test-statically-disable/src/main.rs
+++ b/test-statically-disable/src/main.rs
@@ -10,18 +10,19 @@ use std::time::Duration;
 
 use minitrace::collector::Config;
 use minitrace::collector::ConsoleReporter;
+use minitrace::collector::GlobalCollector;
 
 fn main() {
     use minitrace::local::LocalCollector;
     use minitrace::prelude::*;
 
-    minitrace::set_reporter(
+    minitrace::set_collector(GlobalCollector::new(
         ConsoleReporter,
         Config::default()
             .batch_report_interval(Duration::from_secs(1))
             .max_spans_per_trace(Some(100))
             .batch_report_max_spans(Some(200)),
-    );
+    ));
 
     let mut root = Span::root("root", SpanContext::new(TraceId(0), SpanId(0)))
         .with_property(|| ("k1", "v1"))


### PR DESCRIPTION
Related: https://github.com/tikv/minitrace-rust/issues/184 

This PR does the following:
- Added `trait Collector` for defining the common parts of a collector.
- Change `GlobalCollector` to implement `Colletor` trait 
- Replace `set_reporter` with `set_collector` and allow to pass a collector to manage the spans. 

Questions:
- How to avoid reimplementing the same processing flow in each collector? should this be extracted into a `trait Processor` of some kind?
- Does `GlobalCollector` need to be renamed into something like `AsyncBatchingCollector`? 
- Is this even a good direction? 🤔 