### PR TITLE
Replace println calls with log calls

### DIFF
--- a/minitrace-datadog/Cargo.toml
+++ b/minitrace-datadog/Cargo.toml
@@ -13,6 +13,7 @@ categories = ["development-tools::debugging"]
 keywords = ["tracing", "span", "datadog", "jaeger", "opentelemetry"]
 
 [dependencies]
+log = "0.4"
 minitrace = { version = "0.6.3", path = "../minitrace" }
 reqwest = { version = "0.11", features = ["blocking"] }
 rmp-serde = "1"

--- a/minitrace-datadog/src/lib.rs
+++ b/minitrace-datadog/src/lib.rs
@@ -88,10 +88,11 @@ impl Reporter for DatadogReporter {
         }
 
         if let Err(err) = self.try_report(spans) {
-            eprintln!("report to datadog failed: {}", err);
+            log::error!("report to datadog failed: {}", err);
         }
     }
 }
+
 #[derive(Serialize)]
 struct DatadogSpan<'a> {
     name: &'a str,

--- a/minitrace-jaeger/src/lib.rs
+++ b/minitrace-jaeger/src/lib.rs
@@ -139,7 +139,7 @@ impl Reporter for JaegerReporter {
         }
 
         if let Err(err) = self.try_report(spans) {
-            eprintln!("report to jaeger failed: {}", err);
+            log::error!("report to jaeger failed: {}", err);
         }
     }
 }

--- a/minitrace-opentelemetry/src/lib.rs
+++ b/minitrace-opentelemetry/src/lib.rs
@@ -123,7 +123,7 @@ impl Reporter for OpenTelemetryReporter {
         }
 
         if let Err(err) = self.try_report(spans) {
-            eprintln!("report to opentelemetry failed: {}", err);
+            log::error!("report to opentelemetry failed: {}", err);
         }
     }
 }


### PR DESCRIPTION
This will allow users to format & redirect these messages via commonly used log libraries. `minitrace-jaeger` and `minitrace-opentelemetry` already had  `log` dependency, so this was intended, but never actually implemented?