### PR TITLE
update minitrate-opentelemetry to latest opentelemetry versions

### DIFF
--- a/minitrace-opentelemetry/Cargo.toml
+++ b/minitrace-opentelemetry/Cargo.toml
@@ -16,10 +16,10 @@ keywords = ["tracing", "span", "datadog", "jaeger", "opentelemetry"]
 futures = { version = "0.3", features = ["executor"] }
 log = "0.4"
 minitrace = { version = "0.6.4", path = "../minitrace" }
-opentelemetry = { version = "0.21", features = ["trace"] }
-opentelemetry_sdk = { version = "0.21", features = ["trace"] }
+opentelemetry = { version = "0.22", features = ["trace"] }
+opentelemetry_sdk = { version = "0.22.1", features = ["trace"] }
 
 [dev-dependencies]
-opentelemetry-otlp = { version = "0.14", features = ["trace"] }
+opentelemetry-otlp = { version = "0.15", features = ["trace"] }
 rand = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread"] }

--- a/minitrace-opentelemetry/src/lib.rs
+++ b/minitrace-opentelemetry/src/lib.rs
@@ -22,7 +22,8 @@ use opentelemetry::StringValue;
 use opentelemetry::Value;
 use opentelemetry_sdk::export::trace::SpanData;
 use opentelemetry_sdk::export::trace::SpanExporter;
-use opentelemetry_sdk::trace::EvictedQueue;
+use opentelemetry_sdk::trace::SpanEvents;
+use opentelemetry_sdk::trace::SpanLinks;
 use opentelemetry_sdk::Resource;
 
 /// [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-rust) reporter for `minitrace`.
@@ -70,7 +71,7 @@ impl OpenTelemetryReporter {
                     + Duration::from_nanos(span.begin_time_unix_ns + span.duration_ns),
                 attributes: Self::convert_properties(&span.properties),
                 events: Self::convert_events(&span.events),
-                links: EvictedQueue::new(0),
+                links: SpanLinks::default(),
                 status: Status::default(),
                 span_kind: self.span_kind.clone(),
                 resource: self.resource.clone(),
@@ -90,9 +91,9 @@ impl OpenTelemetryReporter {
         map
     }
 
-    fn convert_events(events: &[EventRecord]) -> EvictedQueue<Event> {
-        let mut queue = EvictedQueue::new(u32::MAX);
-        queue.extend(events.iter().map(|event| {
+    fn convert_events(events: &[EventRecord]) -> SpanEvents {
+        let mut queue = SpanEvents::default();
+        queue.events.extend(events.iter().map(|event| {
             Event::new(
                 event.name.clone(),
                 UNIX_EPOCH + Duration::from_nanos(event.timestamp_unix_ns),

--- a/minitrace/Cargo.toml
+++ b/minitrace/Cargo.toml
@@ -41,9 +41,10 @@ minitrace-jaeger = { version = "0.6.4", path = "../minitrace-jaeger" }
 minitrace-opentelemetry = { version = "0.6.4", path = "../minitrace-opentelemetry" }
 mockall = "0.11"
 once_cell = "1"
-opentelemetry = { version = "0.21", features = ["trace"] }
-opentelemetry-otlp = { version = "0.14", features = ["trace"] }
-opentelemetry_sdk = { version = "0.21" }
+opentelemetry-otlp = { version = "0.15", features = ["trace"] }
+opentelemetry = { version = "0.22", features = ["trace"] }
+opentelemetry_sdk = { version = "0.22.1", features = ["trace"] }
+
 rand = "0.8"
 rustracing = "0.6"
 serial_test = "2"


### PR DESCRIPTION
This upgrades to opentelemetry 0.22,  opentelemetry_sdk 0.22.1  and otlp: 0.15 and tweaks the corresponding API usage to match