### PR TITLE
fix: add tokio rt-multi-thread for example

### DIFF
--- a/minitrace/Cargo.toml
+++ b/minitrace/Cargo.toml
@@ -48,7 +48,7 @@ rand = "0.8"
 rustracing = "0.6"
 serial_test = "2"
 test-harness = "0.1.1"
-tokio = { version = "1", features = ["rt", "time", "macros"] }
+tokio = { version = "1", features = ["rt", "time", "macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-core = "0.1"
 tracing-opentelemetry = "0.18"


### PR DESCRIPTION
In `/minitrace/examples`, we will need `rt-multi-thread` for Tokio in order to run both the synchronous and asynchronous examples. Here's a screenshot providing evidence:

![image](https://github.com/tikv/minitrace-rust/assets/10728152/a0ca76d1-fbb4-4d87-899b-a47a6c89b6e1)
