### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
-> [!WARNING]
->
-> `minitrace` maintainers have forked this project to [`fastrace`](https://github.com/fastracelabs/fastrace). Please follow the migration guide to update your code. **This repository will no longer be maintained unless anyone else takes responsibility**.
+![](./etc/img/head-img-640.svg)
 
-Edit your `Cargo.toml` and find and replace `minitrace` with `fastrace` in the source code:
+# minitrace has become [fastrace](https://github.com/fastracelabs/fastrace)!
+
+We decide to continue the development of minitrace under a new organization structure for better community governance.
+
+[fastrace](https://github.com/fastracelabs/fastrace) is maintained by the same maintainers of minitrace, so that we encourage all users to just migrate.
+
+Meanwhile, minitrace will not be maintained any more. See https://github.com/tikv/minitrace-rust/issues/229 for details.
+
+## Migrate to fastrace
+
+Simply substitute the occurance of `minitrace` with `fastrace` in your source code, like:
 
 ```diff
 # Cargo.toml


### PR DESCRIPTION
Clearify that fastrace is set up by the same maintainers of minitrace to encourage users to transit.

A better way would be just transfer the ownership of the repository into the new organization so that history issues, pulls will be kept and GitHub will set up redirection for us. However it may require some procedural works and may take time to finish. Before that, this README would be a better one.

cc @andylokandy 