### PR TITLE
fix: wasm function call

### DIFF
--- a/minitrace/src/collector/global_collector.rs
+++ b/minitrace/src/collector/global_collector.rs
@@ -89,7 +89,7 @@ pub fn flush() {
         #[cfg(target_family = "wasm")]
         {
             let mut global_collector = GLOBAL_COLLECTOR.lock();
-            global_collector.handle_commands(true);
+            global_collector.as_mut().unwrap().handle_commands();
         }
 
         #[cfg(not(target_family = "wasm"))]


### PR DESCRIPTION
currently, this wasm call is using an outdated function definition, the new one doesn't accept a `flush` argument, and returns an `Option` https://github.com/tikv/minitrace-rust/blob/d679456de432728170ed319cba2bd86ad5afe1f5/minitrace/src/collector/global_collector.rs#L248